### PR TITLE
removed extra semi-colon - noncompliant code

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class bitbnsApi{
       timeStamp_nonce : timeStamp_nonce,
       body: body
     };
-    return new Buffer(JSON.stringify(data)).toString('base64');;
+    return new Buffer(JSON.stringify(data)).toString('base64');
   }
   getSignature(payload, apiSecretKey){
     return crypto.createHmac('sha512',apiSecretKey)


### PR DESCRIPTION
There is a extra semi-colon that is placed. Extra semicolons (;) are usually introduced by mistake. This falls under noncompliant code.
So I have removed the extra semi-colon.